### PR TITLE
Add Rector with fluent config builder

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,27 @@ jobs:
             - name: "Run friendsofphp/php-cs-fixer"
               run: "vendor/bin/php-cs-fixer fix --diff --dry-run --verbose"
 
+    rector:
+        name: "Rector"
+
+        runs-on: "ubuntu-latest"
+
+        steps:
+            - name: "Checkout"
+              uses: "actions/checkout@v6"
+
+            - name: "Install PHP with extensions"
+              uses: "shivammathur/setup-php@v2"
+              with:
+                  coverage: "none"
+                  php-version: "8.2"
+
+            - name: "Install dependencies with composer"
+              uses: "ramsey/composer-install@v3"
+
+            - name: "Run rector/rector"
+              run: "vendor/bin/rector --dry-run"
+
     composer-normalize:
         name: composer-normalize
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendor/
 composer.lock
+.build/
 .phpunit.cache/
 .phpunit.result.cache
 .php-cs-fixer.cache

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ phpstan: vendor
 cs: vendor
 	php vendor/bin/php-cs-fixer fix --diff --verbose
 
+.PHONY: rector
+rector:
+	symfony php vendor/bin/rector
+
 .PHONY: test
 test: vendor
 	php vendor/bin/phpunit -v

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "ergebnis/data-provider": "^3.0",
         "ergebnis/php-cs-fixer-config": "^6.0",
         "phpstan/phpstan": "^2.1",
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^10.5",
+        "rector/rector": "^2.3"
     },
     "config": {
         "sort-packages": true

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Attribute\SortAttributeNamedArgsRector;
+use Rector\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRector;
+use Rector\CodeQuality\Rector\FuncCall\SimplifyRegexPatternRector;
+use Rector\CodeQuality\Rector\FuncCall\SortCallLikeNamedArgsRector;
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
+use Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector;
+use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector;
+use Rector\ValueObject\PhpVersion;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__.'/rector.php',
+        __DIR__.'/src',
+        __DIR__.'/tests',
+    ])
+    ->withCache('.build/rector')
+    ->withPhpVersion(PhpVersion::PHP_82)
+    ->withImportNames(importShortClasses: false)
+    ->withParallel()
+    ->withPhpSets()
+    ->withComposerBased(phpunit: true)
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        earlyReturn: true,
+        phpunitCodeQuality: true,
+    )
+    ->withSkip([
+        SortAttributeNamedArgsRector::class,
+        SortCallLikeNamedArgsRector::class,
+        SimplifyRegexPatternRector::class, // Keep explicit regex patterns for better readability
+        RemoveUnusedPublicMethodParameterRector::class => [
+            __DIR__.'/src/EventListener', // Keep event args in listeners for consistency
+        ],
+        RemoveNullArgOnNullDefaultParamRector::class => [
+            __DIR__.'/tests', // Keep explicit null arguments in tests for clarity
+        ],
+        LocallyCalledStaticMethodToNonStaticRector::class,
+        PreferPHPUnitThisCallRector::class,
+        NullToStrictStringFuncCallArgRector::class, // Avoid redundant casts when value is already a string
+    ]);

--- a/src/ReadableFilesizeExtension.php
+++ b/src/ReadableFilesizeExtension.php
@@ -27,7 +27,7 @@ final class ReadableFilesizeExtension extends AbstractExtension
         return [
             new TwigFilter(
                 'readable_filesize',
-                [$this, 'readableFilesize'],
+                $this->readableFilesize(...),
             ),
         ];
     }


### PR DESCRIPTION
## Summary
- Add `rector/rector` as a dev dependency
- Create `rector.php` using the new fluent `RectorConfig::configure()` builder
- Add `.build/` to `.gitignore` for Rector cache
- Add `make rector` target to Makefile
- Add Rector job to CI workflow

## Test plan
- [x] `php vendor/bin/rector --dry-run` passes without warnings
- [x] All 23 tests pass
- [ ] CI pipeline passes